### PR TITLE
chore(deps): bump dalgo to v0.59.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,10 @@ module github.com/dal-go/dalgo2files
 
 go 1.24.5
 
-require github.com/dal-go/dalgo v0.42.0
+require github.com/dal-go/dalgo v0.59.0
 
 require (
-	github.com/RoaringBitmap/roaring/v2 v2.18.0 // indirect
+	github.com/RoaringBitmap/roaring/v2 v2.18.2 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/strongo/random v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
-github.com/RoaringBitmap/roaring/v2 v2.18.0 h1:h7sS0VqCkfBMGgcHaudJFB4FE6Td71H6svRB2poRnGY=
-github.com/RoaringBitmap/roaring/v2 v2.18.0/go.mod h1:eq4wdNXxtJIS/oikeCzdX1rBzek7ANzbth041hrU8Q4=
+github.com/RoaringBitmap/roaring/v2 v2.18.2 h1:oPq3Cgx//iDuJQVp6xSInAKW34J9CEwE5GmLI2z+Eic=
+github.com/RoaringBitmap/roaring/v2 v2.18.2/go.mod h1:eq4wdNXxtJIS/oikeCzdX1rBzek7ANzbth041hrU8Q4=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/dal-go/dalgo v0.42.0 h1:fNb0kyvVpWLxIXyKr5ZwRKhTdLyQxzdDzzBUgUsbfWY=
-github.com/dal-go/dalgo v0.42.0/go.mod h1:mGR/cl9X6O2QCmu1FzrM8gVgFkkhdR33Ur3msnJJJXU=
+github.com/dal-go/dalgo v0.59.0 h1:IKJru3MmZ7DlR9BGc5zToNelHAg3rL7OFYgZrs9VRqI=
+github.com/dal-go/dalgo v0.59.0/go.mod h1:20tJJx7yt8qI8CZhUv1E/Q0HbIDRZXLVBU3JMzDpdvU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=


### PR DESCRIPTION
## Summary
- Upgrades `github.com/dal-go/dalgo` from v0.42.0 to v0.59.0 (transitively bumps `roaring/v2` v2.18.0 → v2.18.2).
- No code changes required: the adapter already implements `Exists`, `ExecuteQueryToRecordsReader` and `ExecuteQueryToRecordsetReader`, and read/write transactions return `ErrNotSupported`/`ErrNotImplementedYet`, so the v0.59.0 `dal.DB` surface is satisfied as-is.

## Test plan
- `go build ./...` — green
- `go vet ./...` — green
- `go test ./...` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)