### PR TITLE
ci: add Go CI workflow with auto semver tagging on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Go CI
+
+on:
+  push:
+    branches-ignore:
+      - renovate/**
+    tags:
+      - 'v[0-9]+\.[0-9]+\.[0-9]+' # Push events to matching v*, i.e. v20.15.10
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+
+  strongo_workflow:
+    permissions:
+      contents: write
+    uses: strongo/go-ci-action/.github/workflows/workflow.yml@main
+
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/database.go
+++ b/database.go
@@ -82,7 +82,7 @@ func (d database) individualFilePath(key *dal.Key) string {
 // Get loads a record by key according to schema definitions.
 func (d database) Get(_ context.Context, record dal.Record) error {
 	key := record.Key()
-	collectionDef := d.SchemaDefinition.GetCollectionDef(key)
+	collectionDef := d.GetCollectionDef(key)
 	// Ensure collection directory exists for read path (no creation). If not exists -> not found
 	switch collectionDef.StoreRecordsAs {
 	case StoreCollectionRecordsIndividualFiles:
@@ -112,7 +112,7 @@ func (d database) Get(_ context.Context, record dal.Record) error {
 			}
 			return record.SetError(err).Error()
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 		dec := json.NewDecoder(f)
 		// Expect an array of objects: [{"id": <id>, "data": <record>}, ...]
 		tok, err := dec.Token()
@@ -162,7 +162,7 @@ func (d database) Get(_ context.Context, record dal.Record) error {
 }
 
 func (d database) Exists(_ context.Context, key *dal.Key) (bool, error) {
-	collectionDef := d.SchemaDefinition.GetCollectionDef(key)
+	collectionDef := d.GetCollectionDef(key)
 	switch collectionDef.StoreRecordsAs {
 	case StoreCollectionRecordsIndividualFiles:
 		if _, err := os.Stat(d.individualFilePath(key)); err != nil {
@@ -181,7 +181,7 @@ func (d database) Exists(_ context.Context, key *dal.Key) (bool, error) {
 			}
 			return false, err
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 		dec := json.NewDecoder(f)
 		// Expect array as above
 		tok, err := dec.Token()

--- a/database_test.go
+++ b/database_test.go
@@ -22,7 +22,7 @@ func TestNewDB_DirectoryValidation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create temp dir: %v", err)
 		}
-		defer os.RemoveAll(tempDir)
+		defer func() { _ = os.RemoveAll(tempDir) }()
 
 		_, err = NewDB(tempDir, schemaDefinition{})
 		if err != nil {
@@ -35,8 +35,8 @@ func TestNewDB_DirectoryValidation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create temp file: %v", err)
 		}
-		defer os.Remove(tempFile.Name())
-		tempFile.Close()
+		defer func() { _ = os.Remove(tempFile.Name()) }()
+		_ = tempFile.Close()
 
 		_, err = NewDB(tempFile.Name(), schemaDefinition{})
 		if err == nil {


### PR DESCRIPTION
## Summary

- Ports the standard `strongo/go-ci-action` reusable workflow used by all sibling dal-go repos (dalgo2sql, dalgo2sqlite, etc.)
- On every push to `main` the workflow runs lint, build, and test via `strongo/go-ci-action/.github/workflows/workflow.yml@main`
- The reusable workflow's `go_bump` job calls `mathieudutour/github-tag-action@v6.2` to automatically bump and push a semver patch tag after a successful CI run on `main`
- dalgo2files had no `.github/` directory at all — this adds the full CI+tagging pipeline in one file

## Test plan

- [ ] Verify the PR CI run passes (lint, build, test jobs)
- [ ] After merge to main, verify `gh api repos/dal-go/dalgo2files/tags --jq '.[0].name'` returns a `v0.x.x` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)