### PR TITLE
docs: sync dev-approach section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,16 @@
 
 A [DALgo](https://github.com/dal-go) provider to persist data on a file system mainly in human-readable formats like
 JSON/YAML/CSV/etc.
+
+<!-- dev-approach:v1 -->
+## Our approach to development
+
+We build with our own tooling:
+
+- **[SpecScore](https://specscore.md)** — specify requirements as `SpecScore.md` artifacts
+- **[SpecStudio](https://specscore.studio)** — author & manage specs across their lifecycle
+- **[inGitDB](https://ingitdb.com)** — store structured data in Git where applicable
+- **[DALgo](https://dalgo.io)** — data access layer for Go
+- **[cover100.dev](https://cover100.dev)** — drive toward 100% test coverage
+- **[DataTug](https://datatug.io)** — query & explore data
+<!-- /dev-approach -->


### PR DESCRIPTION
Automated update of the **Our approach to development** section by `all-repos sync-readme`.